### PR TITLE
Avoid use of dependsOn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,15 +132,16 @@ subprojects { subproj ->
             annotationProcessor "org.kordamp.jipsy:jipsy-processor:${jipsyVersion}"
         }
 
-        tasks.processResources.dependsOn(tasks.register('generateNativeImageResource', org.kordamp.ikonli.gradle.NativeImageResourceGeneratorTask) { t ->
+        def generateNativeImageResource = tasks.register('generateNativeImageResource', org.kordamp.ikonli.gradle.NativeImageResourceGeneratorTask) {
             String ipn = project.name - 'ikonli-' - '-pack'
 
-            t.outputDirectory.set(file('build/resources/main/META-INF/native-image'))
-            t.groupId.set(project.group)
-            t.artifactId.set(project.name)
-            t.version.set(project."${ipn}Version")
-            t.iconPackName.set(ipn)
-        })
+            outputDirectory = layout.buildDirectory.dir("generated/native-image")
+            groupId = project.group
+            artifactId = project.name
+            version = project."${ipn}Version"
+            iconPackName = ipn
+        }
+        sourceSets.main.resources.srcDir(generateNativeImageResource)
     }
 }
 

--- a/buildSrc/src/main/groovy/org/kordamp/ikonli/gradle/NativeImageResourceGeneratorTask.groovy
+++ b/buildSrc/src/main/groovy/org/kordamp/ikonli/gradle/NativeImageResourceGeneratorTask.groovy
@@ -20,45 +20,35 @@ package org.kordamp.ikonli.gradle
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-import javax.inject.Inject
 import java.nio.file.Files
 
 @CompileStatic
-class NativeImageResourceGeneratorTask extends DefaultTask {
+abstract class NativeImageResourceGeneratorTask extends DefaultTask {
     @OutputDirectory
-    final DirectoryProperty outputDirectory
+    abstract DirectoryProperty getOutputDirectory()
 
     @Input
-    final Property<String> groupId
+    abstract Property<String> getGroupId()
 
     @Input
-    final Property<String> artifactId
+    abstract  Property<String> getArtifactId()
 
     @Input
-    final Property<String> version
+    abstract  Property<String> getVersion()
 
     @Input
-    final Property<String> iconPackName
-
-    @Inject
-    NativeImageResourceGeneratorTask(ObjectFactory objects) {
-        outputDirectory = objects.directoryProperty()
-        groupId = objects.property(String)
-        artifactId = objects.property(String)
-        version = objects.property(String)
-        iconPackName = objects.property(String)
-    }
+    abstract  Property<String> getIconPackName()
 
     @TaskAction
     void generateResourceConfigFile() {
-        File resourceConfig = outputDirectory.get().file("${groupId.get()}/${artifactId.get()}/resources-config.json").asFile
-        Files.createDirectories(resourceConfig.parentFile.toPath())
+        def outputDir = outputDirectory.get().asFile.toPath()
+        def resourceConfig = outputDir.resolve("META-INF/native-image/${groupId.get()}/${artifactId.get()}/resources-config.json")
+        Files.createDirectories(resourceConfig.parent)
 
         resourceConfig.text = """
 {


### PR DESCRIPTION
This commit updates the Gradle build to replace the use of `processResources.dependsOn` with a proper dependency.

The rationale is described here:
   https://melix.github.io/blog/2021/10/gradle-quickie-dependson.html

But in a nutshell: hooking the generation of the resources on the `processResources` task will only work if the `processResources` task is actually called, so it works "by accident" when you generate a jar for example. However, let's say that you have another task, in another plugin, which needs to reason about all available resources, including these generated by other plugins. In that case, that plugin would not see the native image source set.

The fix is actually fairly straightforward: you need to declare that the task contributes to the `resources` source set, and Gradle will automatically handle the task dependencies when needed: result should never depend on the execution of lifecycle tasks.